### PR TITLE
Fix csync signal generation

### DIFF
--- a/vic20.sv
+++ b/vic20.sv
@@ -514,7 +514,7 @@ wire  [5:0] osd_b_in;
 
 wire        vsync_out;
 wire        hsync_out;
-wire        csync_out = (HS_O == VS_O);
+wire        csync_out = ~(~HS_O | ~VS_O);
 
 // a minimig vga->scart cable expects a composite sync signal on the VGA_HS output.
 // and VCC on VGA_VS (to switch into rgb mode)


### PR DESCRIPTION
This PR fixes a minor glitch in the generation of the composite sync signal (csync) that causes the issue described in #3 .

Currently `hsync` and `vsync` (which are both low active) are joined together with:
```
csync = (hsync == vsync)
```
At the very start of the vertical sync, both `hsync` and `vsync` are low and the resulting `csync` should be also low. But it's not because of the `==` used in the above formula. `csync` will become low only after the horizontal sync pulse period. That will appear as a small delay in the restored `vsync` once it is separated on the receiver device. 

My guess is that the AD724 chip uses the exact time of restored-vsync as a reference, causing the composite video signal to be generated incorrectly.

The solution is to join `hsync` and `vsync` simply with a OR:
```
csync = ~(~hsync | ~vsync);  // hsync and vsync are negated
```


