### PR TITLE
fix generation of hsync to not overlap with vsync

### DIFF
--- a/vic20/m6561.vhd
+++ b/vic20/m6561.vhd
@@ -421,7 +421,7 @@ begin
         elsif (hcnt = H_START_M1) then
           hblank <= '0';
         end if;
-        if do_hsync then
+        if do_hsync and vsync='0' then
           hsync <= '1';
         elsif (hcnt = "0000010011") then -- 20 -1
           hsync <= '0';


### PR DESCRIPTION
this is the alternate way of fixing #3

Instead of changing the mixing formula `csync = hsync == vsync` this turns off the hsync pulse when vsync is running, so the two do not overlap.

This PR is exclusive with PR #6, only one of the two has to be merged.