### PR TITLE
load screen pointer at every scan line

### DIFF
--- a/vic20/m6561.vhd
+++ b/vic20/m6561.vhd
@@ -477,16 +477,15 @@ begin
       if (I_ENA_4 = '1') then
         -- counter used for video matrix address
         if (vsync = '1') then
-          last_matrix_cnt(13 downto 9) <= r_screen_mem;
-          last_matrix_cnt( 8 downto 0) <= (others => '0'); -- top left;
+          last_matrix_cnt <= (others => '0'); -- top left;          
         elsif (h_char_last = '1') and v_char_last then
           last_matrix_cnt <= last_matrix_cnt + r_num_cols;
-        end if;
+        end if;        
         if (hsync = '1') then
-          matrix_cnt <= last_matrix_cnt;
+          matrix_cnt <= last_matrix_cnt + (r_screen_mem & "000000000");
         elsif (char_load = '1') then
           matrix_cnt <= matrix_cnt + "1";
-         end if;
+        end if;
 
         -- address
         if (hcnt(1 downto 0) = "01") then


### PR DESCRIPTION
In a real VIC-20 the screen memory pointer is updated at the start of every scan line, but on VIC20_MiST update occurs only at the start of the video frame.

So switching the screen pointer in the middle of the page cause it to be visible only on next frame and not immediately. This manifests as flickering images in programs that use the double buffering technique (e.g. games developed with the [VIC-SSS](https://github.com/theflyingape/vic-sss) sprite library).

This PR fixes this issue; attached is a demo program that shows the flickering (run it on a 16K expanded VIC).

[hello.zip](https://github.com/gyurco/VIC20_MiST/files/3056326/hello.zip)
