### PR TITLE
100% accurate noise generator 

### DIFF
--- a/vic20/m6561.vhd
+++ b/vic20/m6561.vhd
@@ -814,6 +814,7 @@ begin
         -- 'mixer'        
         wave_max_value := unsigned("00"  & r_amplitude);             
         wave_mid_value := unsigned("000" & r_amplitude(3 downto 1)); -- value when sound generator is muted 
+                
         a_sum := "000000";        
         if r_base_enabled='1' then
           if base_sg ='1' then 
@@ -838,13 +839,13 @@ begin
         end if;
         if r_noise_enabled='1' then
           if noise_sg='1' then
-            a_sum := a_sum + wave_max_value;
+            a_sum := a_sum + unsigned("000" & r_amplitude(3 downto 1)); --wave_max_value;
           end if;	
         else	 		    
           if noise_sg='1' then                    
-            a_sum := a_sum + wave_max_value;  -- when muted the noise generator 
+            a_sum := a_sum + unsigned("000" & r_amplitude(3 downto 1)); --wave_max_value;  -- when muted the noise generator 
           else                                -- outputs high if it's in the '1' state
-            a_sum := a_sum + wave_mid_value;       
+            a_sum := a_sum + unsigned("0000" & r_amplitude(3 downto 2)); -- wave_mid_value;       
           end if;	
         end if;		  
         O_AUDIO<=std_logic_vector(a_sum);

--- a/vic20/m6561.vhd
+++ b/vic20/m6561.vhd
@@ -748,8 +748,7 @@ begin
     end if;
   end process;
 
-  p_sound_gen : process (I_CLK) is
-    variable noise_zero : std_ulogic;
+  p_sound_gen : process (I_CLK) is    
     variable a_sum : unsigned(5 downto 0); -- sum is 0 to 4*15	
     variable wave_max_value : unsigned(5 downto 0);
     variable wave_mid_value : unsigned(5 downto 0);
@@ -790,11 +789,6 @@ begin
         end if;
         soprano_sg <= soprano_sg_sreg(0);
         
-        -- noise gen
-        noise_zero := '0';
-        if noise_LFSR = 0 then
-          noise_zero := '1';
-        end if;
         -- noise gen        
         if audio_div_8 then          
           if noise_sg_cnt = "1111111" then

--- a/vic20/m6561.vhd
+++ b/vic20/m6561.vhd
@@ -794,20 +794,17 @@ begin
           noise_zero := '1';
         end if;
         
-        if audio_div_16 then
-          if r_noise_enabled='1' then  -- advance only when generator is enabled
-            if noise_sg_cnt = "1111111" then
-              noise_sg_cnt <= r_noise_freq + "1";
-              if noise_LFSR(0)='1' then 
-                noise_sg_sreg <= noise_sg_sreg(6 downto 0) & (not noise_sg_sreg(7) and r_noise_enabled);
-              end if;              
-              noise_LFSR(15 downto 2) <= noise_LFSR(14 downto 1);
-              noise_LFSR(1)           <= noise_LFSR(0) xor noise_zero;
-              noise_LFSR(0)           <= noise_LFSR(3) xor noise_LFSR(12) xor noise_LFSR(14) xor noise_LFSR(15);              
-            else
-              noise_sg_cnt <= noise_sg_cnt + "1";
-            end if;
-          end if;	 
+        if audio_div_16 then          
+          if noise_sg_cnt = "1111111" then
+            noise_sg_cnt <= r_noise_freq + "1";
+            if noise_LFSR(0)='1' then 
+              noise_sg_sreg <= noise_sg_sreg(6 downto 0) & (not noise_sg_sreg(7) and r_noise_enabled);
+            end if;              
+            noise_LFSR(15 downto 1) <= noise_LFSR(14 downto 0);            
+            noise_LFSR(0)           <= ((noise_LFSR(3) xor noise_LFSR(12)) xnor (noise_LFSR(14) xor noise_LFSR(15))) nand r_noise_enabled;              
+          else
+            noise_sg_cnt <= noise_sg_cnt + "1";
+          end if;          
         end if;
         noise_sg <= noise_sg_sreg(0);
         

--- a/vic20/m6561.vhd
+++ b/vic20/m6561.vhd
@@ -832,13 +832,13 @@ begin
         end if;
         if r_noise_enabled='1' then
           if noise_sg='1' then
-            a_sum := a_sum + unsigned("000" & r_amplitude(3 downto 1)); --wave_max_value;
+            a_sum := a_sum + wave_max_value;
           end if;	
         else	 		    
           if noise_sg='1' then                    
-            a_sum := a_sum + unsigned("000" & r_amplitude(3 downto 1)); --wave_max_value;  -- when muted the noise generator 
+            a_sum := a_sum + wave_max_value;  -- when muted the noise generator 
           else                                -- outputs high if it's in the '1' state
-            a_sum := a_sum + unsigned("0000" & r_amplitude(3 downto 2)); -- wave_mid_value;       
+            a_sum := a_sum + wave_mid_value;       
           end if;	
         end if;		  
         O_AUDIO<=std_logic_vector(a_sum);

--- a/vic20/m6561.vhd
+++ b/vic20/m6561.vhd
@@ -794,11 +794,11 @@ begin
           noise_zero := '1';
         end if;
         
-        if audio_div_32 then
+        if audio_div_64 then
           if r_noise_enabled='1' then  -- advance only when generator is enabled
             if noise_sg_cnt = "1111111" then
               noise_sg_cnt <= r_noise_freq + "1";
-              noise_sg_sreg <= noise_sg_sreg(6 downto 0) & (not noise_sg_sreg(7) and r_soprano_enabled);
+              noise_sg_sreg <= noise_sg_sreg(6 downto 0) & (not noise_sg_sreg(7) and r_noise_enabled);
               noise_LFSR(15 downto 2) <= noise_LFSR(14 downto 1);
               noise_LFSR(1)           <= noise_LFSR(0) xor noise_zero;
               noise_LFSR(0)           <= noise_LFSR(3) xor noise_LFSR(12) xor noise_LFSR(14) xor noise_LFSR(15);              

--- a/vic20/m6561.vhd
+++ b/vic20/m6561.vhd
@@ -240,6 +240,7 @@ architecture RTL of M6561 is
   signal audio_div_64     : boolean;
   signal audio_div_32     : boolean;
   signal audio_div_16     : boolean;
+  signal audio_div_8      : boolean;
 
   signal base_sg          : std_logic;
   signal base_sg_cnt      : std_logic_vector(6 downto 0) := (others => '0');
@@ -742,6 +743,7 @@ begin
         audio_div_64   <= audio_div(5 downto 0) =  "000000";
         audio_div_32   <= audio_div(4 downto 0) =   "00000";
         audio_div_16   <= audio_div(3 downto 0) =    "0000";
+        audio_div_8    <= audio_div(2 downto 0) =     "000";
 		end if;
     end if;
   end process;
@@ -793,8 +795,8 @@ begin
         if noise_LFSR = 0 then
           noise_zero := '1';
         end if;
-        
-        if audio_div_16 then          
+        -- noise gen        
+        if audio_div_8 then          
           if noise_sg_cnt = "1111111" then
             noise_sg_cnt <= r_noise_freq + "1";
             if noise_LFSR(0)='1' then 

--- a/vic20/m6561.vhd
+++ b/vic20/m6561.vhd
@@ -5,10 +5,6 @@
 --
 -- POTX/Y not implemented
 -- light pen may not be correct
-
--- The noise generator is not 100% accurate. I am fairly sure it is a LFSR
--- of length 18 or 19, however I have not found the taps which reproduce the
--- waveform of a real device.
 -- 
 -- All rights reserved
 -- (c) copyright 2003-2009 by MikeJ (Mike Johnson)
@@ -57,8 +53,8 @@
 
 -- A more accurate implementation of the three sound voices has been coded 
 -- according to the model theorized by Viznut/pwp at http://www.pelulamu.net/pwp/vic20/waveforms.txt 
--- Noise was generator decoded by Lance Ewing from the 6561 die shot
--- and found to be a 16-bit maximal length LFSR (with feedback bits 3,12,14 and 15)
+-- The noise generator was implemented thanks to the work of Lance Ewing 
+-- who reverse engineered it from the 6561 die shot.
 
 library ieee ;
   use ieee.std_logic_1164.all ;

--- a/vic20/m6561.vhd
+++ b/vic20/m6561.vhd
@@ -794,7 +794,7 @@ begin
           noise_zero := '1';
         end if;
         
-        if audio_div_64 then
+        if audio_div_16 then
           if r_noise_enabled='1' then  -- advance only when generator is enabled
             if noise_sg_cnt = "1111111" then
               noise_sg_cnt <= r_noise_freq + "1";
@@ -807,7 +807,7 @@ begin
             end if;
           end if;	 
         end if;
-        noise_sg <= noise_sg_sreg(0) and noise_LFSR(0);
+        noise_sg <= noise_sg_sreg(0) xor noise_LFSR(0);
         
         -- 'mixer'        
         wave_max_value := unsigned("00"  & r_amplitude);             

--- a/vic20/m6561.vhd
+++ b/vic20/m6561.vhd
@@ -798,7 +798,9 @@ begin
           if r_noise_enabled='1' then  -- advance only when generator is enabled
             if noise_sg_cnt = "1111111" then
               noise_sg_cnt <= r_noise_freq + "1";
-              noise_sg_sreg <= noise_sg_sreg(6 downto 0) & (not noise_sg_sreg(7) and r_noise_enabled);
+              if noise_LFSR(0)='1' then 
+                noise_sg_sreg <= noise_sg_sreg(6 downto 0) & (not noise_sg_sreg(7) and r_noise_enabled);
+              end if;              
               noise_LFSR(15 downto 2) <= noise_LFSR(14 downto 1);
               noise_LFSR(1)           <= noise_LFSR(0) xor noise_zero;
               noise_LFSR(0)           <= noise_LFSR(3) xor noise_LFSR(12) xor noise_LFSR(14) xor noise_LFSR(15);              
@@ -807,7 +809,7 @@ begin
             end if;
           end if;	 
         end if;
-        noise_sg <= noise_sg_sreg(0) xor noise_LFSR(0);
+        noise_sg <= noise_sg_sreg(0);
         
         -- 'mixer'        
         wave_max_value := unsigned("00"  & r_amplitude);             


### PR DESCRIPTION
This PR implements the noise generator of the VIC-20 according to the latest results of the reverse engineering work done by Lance Ewing (on a shot of the 6561 die!).

Previously unknown, in the past days he found that the noise generator is made of a 16-bit LFSR with feedback taps 3,12,14 and 15. All the details are in [this thread](http://sleepingelephant.com/ipw-web/bulletin/bb/viewtopic.php?f=11&t=8733&start=210) on the Denial forum.

This is the resulting FPGA implementation. I tested it against a real VIC-20 and it sounds almost identical to the real hardware. You can hear the same repeating pattern produced when LFSR loops over (e.g `POKE 36877,254`).

Some further detail may emerge in the following days as soon as Lance discover new things, but as regards the emulation/implementation of the noise generator, I would say it's complete.
