### PR TITLE
Fix saturated sound / selectable filter from OSD

### DIFF
--- a/vic20.sv
+++ b/vic20.sv
@@ -73,6 +73,7 @@ localparam CONF_STR =
     "O45,Enable 8K+ Expansion,Off,8K,16K,24K;",
     "O6,Enable 3K Expansion,Off,On;",
     "O78,Enable 8k ROM,Off,RO,RW;",
+	 "O9,Audio filter,On,Off;",
     "T0,Reset;",
     "T1,Reset with cart unload;",
     "V,v1.0.",`BUILD_DATE
@@ -246,6 +247,7 @@ wire        st_ntsc                = status[3];
 wire  [1:0] st_ram_expansion       = status[5:4];
 wire        st_3k_expansion        = status[6];
 wire  [1:0] st_8k_rom              = status[8:7];
+wire        st_audio_filter_off    = status[9];
 wire  [1:0] st_scanlines           = status[11:10];
 
 wire [31:0] sd_lba;
@@ -355,6 +357,7 @@ vic20 VIC20
     .I_RAM_EXT({&st_ram_expansion, st_ram_expansion[1], |st_ram_expansion, st_3k_expansion}), //at $6000(8k),$4000(8k),$2000(8k),$0400(3k)
 
     .O_AUDIO(vic_audio),
+	 .i_audio_filter_off(st_audio_filter_off),
 
     .o_extmem_sel(sdram_en),
     .o_extmem_r_wn(sdram_wr_n),

--- a/vic20/vic20.vhd
+++ b/vic20/vic20.vhd
@@ -91,6 +91,8 @@ entity VIC20 is
     i_restore_out         : in    std_logic;                    -- take care, positive logic (1=>pressed)
 	 --
     o_audio               : out   std_logic_vector(15 downto 0); -- runs at SYSCLK/SYSCLK_EN rate
+	 i_audio_filter_off    : in    std_logic;
+	 
     -- back to system DRAM controller for external memory and cartridges, just map 1:1 to VIC memory
     o_extmem_sel          : out   std_logic;
     o_extmem_r_wn         : out   std_logic;
@@ -503,7 +505,7 @@ begin
           dout_o  => NTSC_audio_filtered
         );
 
-  O_AUDIO <= PAL_audio_filtered when i_pal='1' else NTSC_audio_filtered;  
+  O_AUDIO <= vic_audio & "0000000000" when i_audio_filter_off = '1' else PAL_audio_filtered when i_pal='1' else NTSC_audio_filtered;  
 	
   via1 : entity work.M6522
     port map (

--- a/vic20/vic20.vhd
+++ b/vic20/vic20.vhd
@@ -505,7 +505,7 @@ begin
           dout_o  => NTSC_audio_filtered
         );
 
-  O_AUDIO <= vic_audio & "0000000000" when i_audio_filter_off = '1' else PAL_audio_filtered when i_pal='1' else NTSC_audio_filtered;  
+  O_AUDIO <= vic_audio & "0000000000" when i_audio_filter_off = '1' else PAL_lp_filtered when i_pal='1' else NTSC_lp_filtered;  
 	
   via1 : entity work.M6522
     port map (


### PR DESCRIPTION
There is a problem with the highpass audio filter (the 3rd of the three chained filters) that makes sound very distorted. 

I wasn't able to fix the problem, but I guess it's something related to signed/unsigned result that changes if you use an HP or LP. Look at this comment (`rc_filter_1o.vhd` around line 126):
```vhd
    if (highpass_g) then
      [...]    
      -- output is signed, so the filter has a gain of 0.5 if input and output width is the same
      dout_o <= std_logic_vector(outsum_q_s(dwidtho_g downto 1));
    else
      -- output is unsigned, the filter has a gain of 1.0 if input and output width is the same
      dout_o <= std_logic_vector(dlocal_s(dwidthi_g+cwidth_g-1 downto cwidth_g-dwidtho_g+dwidthi_g));
    end if;
```

With this PR I have disabled the problematic HP filter, keeping the other two. (Until we find a fix for it--anyway it shouldn't be a big audible difference).

Also, due to the 1.6 KHz LP (the second filter), the resulting audio is very "muffled" like the original hardware; so I put an OSD option to turn off filters altogether. (Default is "filter on").

Turning the filter off mimics a common MOD that is done on the capacitor of this filter, for example see [this](http://rga24.blogspot.com/2008/09/vic-20-audio-modification.html) and [this](http://sleepingelephant.com/ipw-web/bulletin/bb/viewtopic.php?f=11&t=2854).







