### PR TITLE
Upstreamfixes

### DIFF
--- a/c1541/c1541_sd.vhd
+++ b/c1541/c1541_sd.vhd
@@ -33,6 +33,7 @@ port(
 	
 	disk_num : in std_logic_vector(9 downto 0);
 	disk_change : in std_logic;
+	disk_mount  : in std_logic := '1';
 	disk_readonly : in std_logic;
 
 	iec_atn_i  : in std_logic;
@@ -112,6 +113,7 @@ signal save_track_stage : std_logic_vector(3 downto 0);
 
 signal wps_flag : std_logic;
 signal change_timer : integer;
+signal mounted : std_logic := '0';
 
 signal dbg_sector : std_logic_vector(4 downto 0); 
 signal dbg_adr_fetch : std_logic_vector(15 downto 0); 
@@ -136,6 +138,7 @@ component mist_sd_card port
 
 		save_track     : in  std_logic;
 		change         : in  std_logic;                     -- Force reload as disk may have changed
+		mount          : in  std_logic;                     -- insert(1)/remove(0)
 		track          : in  std_logic_vector(5 downto 0);  -- Track number (0-34)
 		busy           : out std_logic;
 
@@ -204,6 +207,7 @@ port map
 	byte_n => byte_n, -- byte ready
 
 	track_num  => new_track_num_dbl(6 downto 1),
+	mounted    => mounted,
 
 	ram_addr   => floppy_ram_addr,
 	ram_do     => ram_do, 	
@@ -232,6 +236,7 @@ port map
 	save_track    => save_track,
 	sector_offset => sector_offset,
 	change        => disk_change,
+	mount         => disk_mount,
 
 	sd_buff_addr => sd_buff_addr,
 	sd_buff_dout => sd_buff_dout,
@@ -278,6 +283,7 @@ begin
 		change_timer <= 0;
 	elsif rising_edge(clk32) then
 		if disk_change = '1' then
+			mounted <= disk_mount;
 			change_timer <= 1000000;
 		elsif change_timer /= 0 then
 			change_timer <= change_timer - 1;
@@ -294,6 +300,7 @@ begin
 		if reset = '1' then
 			track_num_dbl <= "0100100";--"0000010";
 			track_modified <= '0';
+			save_track <= '0';
 			save_track_stage <= X"0";
 		else
 			if mtr = '1' then

--- a/c1541/gcr_floppy.vhd
+++ b/c1541/gcr_floppy.vhd
@@ -29,6 +29,7 @@ port(
 	byte_n : out std_logic;                      -- byte ready
 	
 	track_num   : in  std_logic_vector(5 downto 0);
+	mounted     : in  std_logic;
 	
 	ram_addr    : out std_logic_vector(12 downto 0);
 	ram_do      : in  std_logic_vector(7 downto 0);
@@ -206,7 +207,7 @@ begin
 
 	  if old_track /= track_num then
 	    sector <= (others => '0'); --reset sector number on track change
-	  elsif bit_clk_en = '1' then
+	  elsif mounted = '1' and bit_clk_en = '1' then
 
 		mode_r2 <= mode;
 		if mode = '1' then autorise_write <= '0'; end if;

--- a/c1541/mist_sd_card.sv
+++ b/c1541/mist_sd_card.sv
@@ -36,6 +36,7 @@ module mist_sd_card
 
 	input         save_track,
 	input         change,
+	input         mount,
 	input   [5:0] track,
 
 	output [12:0] ram_addr,
@@ -67,7 +68,7 @@ always @(posedge clk) begin
 	reg saving = 0;
 
 	old_change <= change;
-	if(~old_change & change) ready <= 1;
+	if(~old_change & change) ready <= mount;
 
 	old_ack <= sd_ack;
 	if(sd_ack) {sd_rd,sd_wr} <= 0;

--- a/vic20/m6561.vhd
+++ b/vic20/m6561.vhd
@@ -258,7 +258,9 @@ architecture RTL of M6561 is
   signal op_reg           : std_logic_vector(7 downto 0);
 
   signal op_multi         : std_logic;
+  signal op_multi_r       : std_logic;
   signal op_col           : std_logic_vector(2 downto 0);
+  signal op_col_r         : std_logic_vector(2 downto 0);
 
   signal col_mux_sel      : std_logic_vector(3 downto 0);
   signal col_rgb          : std_logic_vector(11 downto 0);
@@ -693,8 +695,8 @@ begin
           op_cnt <= op_cnt_r;
           --buffer character
           op_reg   <= din_reg_char(7 downto 0);
-          op_multi <= din_reg_cell(11);
-          op_col   <= din_reg_cell(10 downto 8);
+          op_multi_r <= din_reg_cell(11);
+          op_col_r   <= din_reg_cell(10 downto 8);
         elsif (op_cnt(3) = '1') then
           op_cnt <= op_cnt + "1";
         end if;
@@ -710,6 +712,10 @@ begin
         -- yuk, a mux. Hang the expense.
         bit_sel <= '0';
 
+		  -- AMR - delay op_multi and op_col to match delay on bit_sel, otherwise colour changes happen a pixel too soon.
+        op_multi <= op_multi_r;
+        op_col   <= op_col_r;
+		  
         case op_cnt(2 downto 0) is
           when "000" => bit_sel <= op_reg(7);
           when "001" => bit_sel <= op_reg(6);

--- a/vic20/vic20.vhd
+++ b/vic20/vic20.vhd
@@ -391,7 +391,12 @@ begin
 	 -- audio filters
 	
 	 -- Filters are running at sysclk which is different in PAL/NTSC
-	 -- so we have to define two different banks of filters 	 
+	 -- so we have to define two different banks of filters 
+	 
+	 -- (Alternatively, we could simply create an ena signal which triggers
+	 -- every 28 or 35 cycles, then use a single filter bank with 
+	 -- fclk_hz_g set to 1MHz - but the filters aren't horrendously expensive. -- AMR) 
+
 
 	 -- we use a well oversampled LP output...
 	 
@@ -399,9 +404,9 @@ begin
    intrinsic_RC_lp_PAL: entity work.rc_filter_1o
     generic map (
           highpass_g   => false,
-          R_ohms_g     => 1000,    -- 1kOhms   \  LP from output
-          C_p_farads_g => 10000,   -- 10 nF    /  with ~16kHz fg
-          fclk_hz_g => sysclk_PAL,    -- we use the sysclk
+          R_ohms_g     => 1000,      -- 1kOhms   \  LP from output
+          C_p_farads_g => 10000,     -- 10 nF    /  with ~16kHz fg
+          fclk_hz_g => sysclk_PAL/4, -- we use the sysclk / 4 (clk_ena freq)
           cwidth_g  => 12,
           dwidthi_g => 6,
           dwidtho_g => 16
@@ -417,9 +422,9 @@ begin
    audio_RC_lp_PAL: entity work.rc_filter_1o
     generic map (
           highpass_g   => false,
-          R_ohms_g     => 1000,    -- 1kOhms   \  LP on PCB
-          C_p_farads_g => 100000,  -- 100 nF   /  with ~1.6kHz fg
-          fclk_hz_g => sysclk_PAL,    -- we use the sysclk
+          R_ohms_g     => 1000,      -- 1kOhms   \  LP on PCB
+          C_p_farads_g => 100000,    -- 100 nF   /  with ~1.6kHz fg
+          fclk_hz_g => sysclk_PAL/4, -- we use the sysclk / 4 (clk_ena freq)
           cwidth_g  => 14,
           dwidthi_g => 16,
           dwidtho_g => 16
@@ -435,9 +440,9 @@ begin
    audio_RC_hp_PAL: entity work.rc_filter_1o
     generic map (
           highpass_g   => true,
-          R_ohms_g     => 1000,      -- 1kOhms   \  HP to connector
-          C_p_farads_g => 1000000,   -- 1 uF     /  with ~160Hz fg
-          fclk_hz_g => sysclk_PAL,      -- we use the sysclk
+          R_ohms_g     => 10000,     -- 10kOhms  \  HP to connector (nominal 10k line load)
+          C_p_farads_g => 1000000,   -- 1 uF     /  with ~16Hz fg
+          fclk_hz_g => sysclk_PAL/4, -- we use the sysclk / 4 (clk_ena freq)
           cwidth_g  => 16,
           dwidthi_g => 16,
           dwidtho_g => 16
@@ -455,9 +460,9 @@ begin
    intrinsic_RC_lp_NTSC: entity work.rc_filter_1o
     generic map (
           highpass_g   => false,
-          R_ohms_g     => 1000,    -- 1kOhms   \  LP from output
-          C_p_farads_g => 10000,   -- 10 nF    /  with ~16kHz fg
-          fclk_hz_g => sysclk_NTSC,    -- we use the sysclk
+          R_ohms_g     => 1000,       -- 1kOhms   \  LP from output
+          C_p_farads_g => 10000,      -- 10 nF    /  with ~16kHz fg
+          fclk_hz_g => sysclk_NTSC/4, -- we use the sysclk / 4 (clk_ena freq)
           cwidth_g  => 12,
           dwidthi_g => 6,
           dwidtho_g => 16
@@ -473,9 +478,9 @@ begin
    audio_RC_lp_NTSC: entity work.rc_filter_1o
     generic map (
           highpass_g   => false,
-          R_ohms_g     => 1000,    -- 1kOhms   \  LP on PCB
-          C_p_farads_g => 100000,  -- 100 nF   /  with ~1.6kHz fg
-          fclk_hz_g => sysclk_NTSC,    -- we use the sysclk
+          R_ohms_g     => 1000,       -- 1kOhms   \  LP on PCB
+          C_p_farads_g => 100000,     -- 100 nF   /  with ~1.6kHz fg
+          fclk_hz_g => sysclk_NTSC/4, -- we use the sysclk / 4 (clk_ena freq)
           cwidth_g  => 14,
           dwidthi_g => 16,
           dwidtho_g => 16
@@ -491,9 +496,9 @@ begin
    audio_RC_hp_NTSC: entity work.rc_filter_1o
     generic map (
           highpass_g   => true,
-          R_ohms_g     => 1000,      -- 1kOhms   \  HP to connector
-          C_p_farads_g => 1000000,   -- 1 uF     /  with ~160Hz fg
-          fclk_hz_g => sysclk_NTSC,      -- we use the sysclk
+          R_ohms_g     => 10000,      -- 10kOhms  \  HP to connector (nominal 10k line load)
+          C_p_farads_g => 1000000,    -- 1 uF     /  with ~16Hz fg
+          fclk_hz_g => sysclk_NTSC/4, -- we use the sysclk / 4 (clk_ena freq)
           cwidth_g  => 16,
           dwidthi_g => 16,
           dwidtho_g => 16


### PR DESCRIPTION
In porting this core to TC64 I've made a couple of bug fixes which are applicable to MiST too:
* Pixel data was lagging behind the colour data by 1 pixel
* The audio filter cutoff frequencies were too low, since fclk_hz_g should be the frequency of the ena signal, i.e. sysclk / 4.
* I've updated the 1541 implementation from the C16 core so that it's disabled when the mounted image size is zero, and also defaulted the save_track signal to zero on reset. 
* Finally, I've simplified the filter setup, to use a single chain with an adaptive ena signal of about 250KHz for both PAL/NTSC, piped the first oversampled filter output to the "unfiltered" audio and removed the high pass filter.  (I don't see any point modelling the VIC's output DC blocking capacitor when the MiST already has equivalent capacitors on its audio output.)

Feel free to merge / cherry-pick as you wish.
